### PR TITLE
sdk_debian: Add generic symlink for the generated rootfs

### DIFF
--- a/sdk_debian/justfile
+++ b/sdk_debian/justfile
@@ -51,6 +51,9 @@ rootfs:
     echo "[*] Removing temporary rootfs"
     rm -rf "${repo_root}/assets/debian/rootfs"
 
+    echo "[*] Creating generic symlink for rootfs"
+    ln -sf "${repo_root}/assets/debian/rootfs-$(date --iso-8601).tar.xz" "${repo_root}/assets/debian/rootfs-latest.tar.xz"
+
     echo "[*] Done"
 
 clear-rootfs:

--- a/sdk_debian/recipe.toml
+++ b/sdk_debian/recipe.toml
@@ -22,7 +22,7 @@ postlude_commands = [ ]
 writable_assets_dirs_at_build = [ ]
 
 [bootstrap]
-rootfs_archive = "{{repo}}/assets/debian/rootfs-2018-07-27.tar.xz"
+rootfs_archive = "{{repo}}/assets/debian/rootfs-latest.tar.xz"
 steps = [
     # Download the source code for all binary packages included in the rootfs:
     "{{repo}}/products/{{product}}/{{recipe}}/scripts/bootstrap.sh",


### PR DESCRIPTION
After rootfs generation, the justfile creates a symlink with a generic
named which links to the latest generated file containing the date in
the name.

Using such a symlink avoids to update recipe.toml with the new rootfs
named when bootstrap-from-scratch target is called.

Relates to [https://github.com/clipos/bugs/issues/7](https://github.com/clipos/bugs/issues/7)